### PR TITLE
fix: adapt benchmark to current TGFX window API and fix macOS CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,6 @@ elseif (WIN32)
     if (TGFX_USE_ANGLE)
         add_definitions(-DTGFX_USE_ANGLE)
         list(APPEND BENCH_INCLUDES ${TGFX_DIR}/vendor/angle/include)
-        file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/libEGL.dll)
-        file(COPY ${TGFX_DIR}/vendor/angle/win/${ARCH}/libEGL.dll DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-        file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/libGLESv2.dll)
-        file(COPY ${TGFX_DIR}/vendor/angle/win/${ARCH}/libGLESv2.dll DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
     endif ()
 endif ()
 
@@ -82,3 +78,11 @@ add_dependencies(Benchmark tgfx)
 target_include_directories(Benchmark PRIVATE ${BENCH_INCLUDES})
 target_compile_options(Benchmark PUBLIC ${BENCH_COMPILE_OPTIONS})
 target_link_libraries(Benchmark tgfx ${BENCHMARK_LIBS})
+
+if (WIN32 AND TGFX_USE_ANGLE)
+    add_custom_command(TARGET Benchmark POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${TGFX_DIR}/vendor/angle/win/${ARCH}/libEGL.dll
+            ${TGFX_DIR}/vendor/angle/win/${ARCH}/libGLESv2.dll
+            $<TARGET_FILE_DIR:Benchmark>)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.13)
 project(TGFX-Benchmark)
 
+if (APPLE)
+    enable_language(OBJC)
+    enable_language(OBJCXX)
+endif ()
+
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 include(./third_party/vendor_tools/vendor.cmake)
 

--- a/DEPS
+++ b/DEPS
@@ -12,7 +12,7 @@
       },
       {
         "url": "${PAG_GROUP}/tgfx.git",
-        "commit": "8d1c38fcb221ba282c371823c4e2e10de48984be",
+        "commit": "4d5949b1979f008fdd804f483aa4d0f23d583035",
         "dir": "third_party/tgfx"
       },
       {

--- a/src/platform/mac/TGFXWindow.mm
+++ b/src/platform/mac/TGFXWindow.mm
@@ -35,6 +35,7 @@
   NSWindow* window;
   NSView* view;
   std::shared_ptr<tgfx::CGLWindow> cglWindow;
+  std::shared_ptr<tgfx::Surface> surface;
   std::unique_ptr<benchmark::AppHost> appHost;
   std::unique_ptr<tgfx::Recording> lastRecording;
   int drawIndex;
@@ -144,10 +145,11 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef, const CVTimeStamp*, const 
   } else {
     appHost->resetFrames();
   }
-  auto contentScale = static_cast<float>(size.height / view.bounds.size.height);
-  auto sizeChanged = appHost->updateScreen(width, height, contentScale);
-  if (sizeChanged && cglWindow != nullptr) {
-    cglWindow->invalidSize();
+  if (width > 0 && height > 0 && view.bounds.size.height > 0) {
+    auto contentScale = static_cast<float>(size.height / view.bounds.size.height);
+    if (appHost->updateScreen(width, height, contentScale)) {
+      surface = nullptr;
+    }
   }
   for (NSTrackingArea* trackingArea in [view trackingAreas]) {
     [view removeTrackingArea:trackingArea];
@@ -173,11 +175,19 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef, const CVTimeStamp*, const 
     return;
   }
   auto device = cglWindow->getDevice();
+  if (device == nullptr) {
+    return;
+  }
   auto context = device->lockContext();
   if (context == nullptr) {
     return;
   }
-  auto surface = cglWindow->getSurface(context);
+  if (surface == nullptr) {
+    if (lastRecording != nullptr) {
+      context->submit(std::move(lastRecording));
+    }
+    surface = tgfx::Surface::MakeFrom(context, cglWindow);
+  }
   if (surface == nullptr) {
     device->unlock();
     return;
@@ -193,7 +203,6 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef, const CVTimeStamp*, const 
   if (recording != nullptr) {
     context->submit(std::move(recording));
   }
-  cglWindow->present(context);
   device->unlock();
   auto drawTime = tgfx::Clock::Now() - currentTime;
   appHost->recordFrame(drawTime);

--- a/src/platform/win/TGFXWindow.cpp
+++ b/src/platform/win/TGFXWindow.cpp
@@ -241,10 +241,12 @@ void TGFXWindow::draw() {
   GetClientRect(windowHandle, &rect);
   auto width = static_cast<int>(rect.right - rect.left);
   auto height = static_cast<int>(rect.bottom - rect.top);
+  if (width <= 0 || height <= 0) {
+    return;
+  }
   auto pixelRatio = getPixelRatio();
-  auto sizeChanged = appHost->updateScreen(width, height, pixelRatio);
-  if (sizeChanged) {
-    tgfxWindow->invalidSize();
+  if (appHost->updateScreen(width, height, pixelRatio)) {
+    surface = nullptr;
   }
   auto device = tgfxWindow->getDevice();
   if (device == nullptr) {
@@ -254,7 +256,12 @@ void TGFXWindow::draw() {
   if (context == nullptr) {
     return;
   }
-  auto surface = tgfxWindow->getSurface(context);
+  if (surface == nullptr) {
+    if (lastRecording != nullptr) {
+      context->submit(std::move(lastRecording));
+    }
+    surface = tgfx::Surface::MakeFrom(context, tgfxWindow);
+  }
   if (surface == nullptr) {
     device->unlock();
     return;
@@ -272,13 +279,8 @@ void TGFXWindow::draw() {
   if (recording != nullptr) {
     context->submit(std::move(recording));
   }
-
-  auto presentStartTime = tgfx::Clock::Now();
-  // Exclude the present time from the draw time to avoid blocking caused by vsync.
-  tgfxWindow->present(context);
-  auto presentTime = tgfx::Clock::Now() - presentStartTime;
   device->unlock();
-  auto drawTime = tgfx::Clock::Now() - currentTime - presentTime;
+  auto drawTime = tgfx::Clock::Now() - currentTime;
   appHost->recordFrame(drawTime);
 }
 }  // namespace benchmark

--- a/src/platform/win/TGFXWindow.h
+++ b/src/platform/win/TGFXWindow.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include "base/Bench.h"
+#include "tgfx/core/Surface.h"
 #ifdef TGFX_USE_ANGLE
 #include "tgfx/gpu/opengl/egl/EGLWindow.h"
 #else
@@ -45,6 +46,7 @@ class TGFXWindow {
  private:
   HWND windowHandle = nullptr;
   std::unique_ptr<tgfx::Recording> lastRecording = nullptr;
+  std::shared_ptr<tgfx::Surface> surface = nullptr;
   int lastDrawIndex = 0;
   std::shared_ptr<AppHost> appHost = nullptr;
 #ifdef TGFX_USE_ANGLE

--- a/web/demo/src/TGFXBaseView.cpp
+++ b/web/demo/src/TGFXBaseView.cpp
@@ -81,9 +81,8 @@ void TGFXBaseView::updateSize(float devicePixelRatio) {
     int width = 0;
     int height = 0;
     emscripten_get_canvas_element_size(canvasID.c_str(), &width, &height);
-    auto sizeChanged = appHost->updateScreen(width, height, devicePixelRatio);
-    if (sizeChanged && window) {
-      window->invalidSize();
+    if (appHost->updateScreen(width, height, devicePixelRatio)) {
+      surface = nullptr;
     }
   }
 }
@@ -112,11 +111,19 @@ void TGFXBaseView::draw() {
     return;
   }
   auto device = window->getDevice();
+  if (device == nullptr) {
+    return;
+  }
   auto context = device->lockContext();
   if (context == nullptr) {
     return;
   }
-  auto surface = window->getSurface(context);
+  if (surface == nullptr) {
+    if (lastRecording != nullptr) {
+      context->submit(std::move(lastRecording));
+    }
+    surface = tgfx::Surface::MakeFrom(context, window);
+  }
   if (surface == nullptr) {
     device->unlock();
     return;
@@ -137,7 +144,6 @@ void TGFXBaseView::draw() {
   if (recording != nullptr) {
     context->submit(std::move(recording));
   }
-  window->present(context);
   device->unlock();
   auto drawTime = tgfx::Clock::Now() - currentTime;
   appHost->recordFrame(drawTime);

--- a/web/demo/src/TGFXBaseView.h
+++ b/web/demo/src/TGFXBaseView.h
@@ -21,6 +21,7 @@
 #include <emscripten/bind.h>
 #include "base/AppHost.h"
 #include "benchmark/ParticleBench.h"
+#include "tgfx/core/Surface.h"
 #include "tgfx/gpu/opengl/webgl/WebGLWindow.h"
 namespace benchmark {
 
@@ -59,6 +60,7 @@ class TGFXBaseView {
 
  private:
   std::shared_ptr<tgfx::Window> window = nullptr;
+  std::shared_ptr<tgfx::Surface> surface = nullptr;
   std::string canvasID = "";
 };
 


### PR DESCRIPTION
## Summary

- Adapt the benchmark to the current TGFX window API.
- Enable `OBJC`/`OBJCXX` languages on Apple platforms in CMake.

## Details

The CMake project compiles `.mm` (Objective-C++) sources on macOS/iOS, but `project()` only enabled C/C++ languages by default. This caused CMake generation to fail with:

```
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_OBJCXX_COMPILE_OBJECT
```

Explicitly enabling `OBJC` and `OBJCXX` for Apple platforms resolves the generation failure and allows the project to build on macOS.